### PR TITLE
Fix network timeout causing hangs

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -8,7 +8,10 @@ import * as transform from './transform.js';
 // Spoof Chrome, just in case
 needle.defaults({
   parse_response: false,
-  user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36'
+  user_agent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36',
+  open_timeout: 5000, // Maximum time to wait to establish a connection
+  response_timeout: 5000, // Maximum time to wait for a response
+  read_timeout: 30000 // Maximum time to wait for data to transfer
 });
 
 // Ignore TLS failures (such as Texas DHHS)
@@ -46,7 +49,7 @@ async function fetch(url, type, date) {
     console.log('  ⚡️ Loading data for %s from %s', url, filePath);
     body = await fs.readFile(filePath);
   }
-  else if (new Date(date) < new Date(transform.getYYYYMD())) {
+  else if (date && new Date(date) < new Date(transform.getYYYYMD())) {
     console.log('  ⚠️  Cannot go back in time to get %s, no cache present', url);
     body = '';
   }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -49,7 +49,7 @@ async function fetch(url, type, date) {
     console.log('  ⚡️ Loading data for %s from %s', url, filePath);
     body = await fs.readFile(filePath);
   }
-  else if (date && new Date(date) < new Date(transform.getYYYYMD())) {
+  else if (new Date(date) < new Date(transform.getYYYYMD())) {
     console.log('  ⚠️  Cannot go back in time to get %s, no cache present', url);
     body = '';
   }


### PR DESCRIPTION
`Needle` by default will wait indefinitely when fetching if the host does not send any data back, or the data takes very long to be retrieved.

An example url causing issue is from the South Dakota website (https://doh.sd.gov/news/Coronavirus.aspx#SD) which does not seem to send any data back currently.

This PR adds default timeouts for opening connections (5s), waiting for a response (5s), and downloading data (30s).

Feel free to let me know if these defaults should be tweaked.