### PR TITLE
Fix cache issue causing undefined error

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -49,7 +49,7 @@ async function fetch(url, type, date) {
     console.log('  ⚡️ Loading data for %s from %s', url, filePath);
     body = await fs.readFile(filePath);
   }
-  else if (new Date(date) < new Date(transform.getYYYYMD())) {
+  else if (date && new Date(date) < new Date(transform.getYYYYMD())) {
     console.log('  ⚠️  Cannot go back in time to get %s, no cache present', url);
     body = '';
   }


### PR DESCRIPTION
Found a potential bug linked to timeseries data (when grabbing the CSV files from  Johns Hopkins repo for example)

Parser reports warning:

```
⚠️  Cannot go back in time to get https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Deaths.csv, no cache present
```

and throws a caught error:

```
TypeError: Cannot convert undefined or null to object
```

It appears we are not grabbing any timeseries data causing this line in `scrappers.js:31` to throw as it assumes that cases will not be empty:

```javascript
let latestDate = Object.keys(cases[0]).pop();
```

Traced the lack of data in cases to `fetch.js:52`:

```javascript
if (await fs.exists(filePath)) {
	// stuff
else if (new Date(date) < new Date(transform.getYYYYMD())) {
	console.log('  ⚠️  Cannot go back in time to get %s, no cache present', url);
	body = '';
}
```

For timeseries data, when no cached files are present, the first equality is false and the second is tested. The `date` parameter is set to `false` for timeseries data. 

This causes `new Date(false) => 1970-01-01`, making the equality `true`. This short-circuits the fetch and we return an empty `body`.

Changing `else if (new Date(date) < new Date(transform.getYYYYMD())) {` to `else if (date && new Date(date) < new Date(transform.getYYYYMD())) {` fixes the issue.
