### PR TITLE
Improve datetime functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test CI
 on: push
 
 jobs:
-  build:
+  test:
     runs-on: [macOS-latest]
     steps:
       - uses: actions/checkout@v1 # without submodules

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -1,77 +1,41 @@
-/*
-  Get a date object offset for the current timezone
-*/
+import moment from 'moment';
+
+/**
+ * Get current UTC date in milliseconds since Epoch
+ */
 function getDate() {
-  let date = new Date();
-  date.setHours(date.getHours() - date.getTimezoneOffset() / 60);
-  return date;
+  return Date.now();
 }
 
-/*
-  Get date formatted in YYYY-M-D
-*/
-function getYYYYMD(date = getDate(), sep = '-') {
-  var month = date.getUTCMonth() + 1;
-  var day = date.getUTCDate();
-  var year = date.getUTCFullYear();
-
-  return `${year}${sep}${month}${sep}${day}`;
-}
-
-/*
-  Get date formatted in YYYY-M-D
-*/
+/**
+ * Formats a date in YYYY-MM-DD. Allows for the customization of the separator.
+ * @param {number} date UTC date in milliseconds since Epoch, defaults to current date
+ * @param {string} sep Separator to use, defaults to "-"
+ */
 function getYYYYMMDD(date = getDate(), sep = '-') {
-  var month = (date.getUTCMonth() + 1).toString().padStart(2, '0');;
-  var day = date.getUTCDate().toString().padStart(2, '0');
-  var year = date.getUTCFullYear();
-
-  return `${year}${sep}${month}${sep}${day}`;
+  return moment(date).format(`YYYY${sep}MM${sep}DD`);
 }
 
-/*
-  Get date formatted in DD-MM-YYYY
-*/
-function getDDMMYYYY(date = getDate(), sep = '-') {
-  var month = (date.getUTCMonth() + 1).toString().padStart(2, '0');;
-  var day = date.getUTCDate().toString().padStart(2, '0');
-  var year = date.getUTCFullYear();
+/**
+ * Compares two dates. Returns true if the **date** element of `a` is before `b`.
+ * @param {number} a UTC date is milliseconds since Epoch
+ * @param {number} b UTC date in milliseconds since Epoch
+ */
+function isDateBefore(a, b) {
+  const yearA = moment(a)
+    .utc()
+    .year();
+  const yearB = moment(b)
+    .utc()
+    .year();
+  const dayOfYearA = moment(a)
+    .utc()
+    .dayOfYear();
+  const dayOfYearB = moment(b)
+    .utc()
+    .dayOfYear();
 
-  return `${day}${sep}${month}${sep}${year}`;
+  return yearA < yearB || (yearA === yearB && dayOfYearA < dayOfYearB);
 }
 
-/*
-  Get date formatted in M/D/YYYY
-*/
-function getMDYYYY(date = getDate(), sep = '/') {
-  var month = date.getUTCMonth() + 1;
-  var day = date.getUTCDate();
-  var year = date.getUTCFullYear();
-
-  return `${month}${sep}${day}${sep}${year}`;
-}
-
-/*
-  Get date formatted in M/D/YY
-*/
-function getMDYY(date = getDate(), sep = '/') {
-  var month = date.getUTCMonth() + 1;
-  var day = date.getUTCDate();
-  var year = date.getUTCFullYear().toString().substr(2, 2);
-
-  return `${month}${sep}${day}${sep}${year}`;
-}
-
-/*
-  Check of the *date* of the passed date is before the other passed date
-  *sigh*
-*/
-function dateIsBefore(a, b) {
-  a = new Date(a);
-  b = new Date(b);
-  a.setHours(0,0,0,0);
-  b.setHours(0,0,0,0);
-  return a < b;
-}
-
-export { getDate, getYYYYMD, getYYYYMMDD, getMDYYYY, getMDYY, getDDMMYYYY, dateIsBefore };
+export { getDate, getYYYYMMDD, isDateBefore };

--- a/lib/datetime.js
+++ b/lib/datetime.js
@@ -1,7 +1,9 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
+
+const DEFAULT_TIMEZONE = 'America/Los_Angeles'; // Pacific Standard Time
 
 /**
- * Get current UTC date in milliseconds since Epoch
+ * Get current date in milliseconds since Epoch
  */
 function getDate() {
   return Date.now();
@@ -13,7 +15,9 @@ function getDate() {
  * @param {string} sep Separator to use, defaults to "-"
  */
 function getYYYYMMDD(date = getDate(), sep = '-') {
-  return moment(date).format(`YYYY${sep}MM${sep}DD`);
+  return moment(date)
+    .tz(DEFAULT_TIMEZONE)
+    .format(`YYYY${sep}MM${sep}DD`);
 }
 
 /**
@@ -23,16 +27,16 @@ function getYYYYMMDD(date = getDate(), sep = '-') {
  */
 function isDateBefore(a, b) {
   const yearA = moment(a)
-    .utc()
+    .tz(DEFAULT_TIMEZONE)
     .year();
   const yearB = moment(b)
-    .utc()
+    .tz(DEFAULT_TIMEZONE)
     .year();
   const dayOfYearA = moment(a)
-    .utc()
+    .tz(DEFAULT_TIMEZONE)
     .dayOfYear();
   const dayOfYearB = moment(b)
-    .utc()
+    .tz(DEFAULT_TIMEZONE)
     .dayOfYear();
 
   return yearA < yearB || (yearA === yearB && dayOfYearA < dayOfYearB);

--- a/lib/datetime.test.js
+++ b/lib/datetime.test.js
@@ -28,11 +28,14 @@ describe('Datetime functions', () => {
 
   describe('isDateBefore', () => {
     const tests = [
-      [1582299098000, 1582299098000, false],
-      [1582299098000, 1585299098000, true],
-      [1584299041000, 1584299541000, false],
-      [1584230399000, 1584230410000, true],
-      [1584230400000, 1584230410000, false]
+      // Sunday, March 15, 2020 12:43:08 PM and Sunday, March 15, 2020 12:59:01 PM
+      [1584301388000, 1584302341000, false],
+      // Saturday, March 14, 2020 12:43:08 PM and Sunday, March 15, 2020 12:43:08 PM
+      [1584214988000, 1584301388000, true],
+      // Saturday, March 14, 2020 11:59:59 PM and Sunday, March 15, 2020 12:00:00 AM
+      [1584255599000, 1584255600000, true],
+      // Sunday, March 15, 2020 12:00:00 AM and Sunday, March 15, 2020 12:00:01 AM
+      [1584255600000, 1584255601000, false]
     ];
     each(tests).test('when passed date %d and date %d, it returns %s', (a, b, expected) => {
       expect(datetime.isDateBefore(a, b)).toBe(expected);

--- a/lib/datetime.test.js
+++ b/lib/datetime.test.js
@@ -1,0 +1,41 @@
+import each from 'jest-each';
+
+import * as datetime from './datetime';
+
+describe('Datetime functions', () => {
+  describe('getDate', () => {
+    test('When called, it returns a number', () => {
+      expect(typeof datetime.getDate() === 'number').toBeTruthy();
+    });
+
+    test('When called, returns the current time in milliseconds', () => {
+      expect(Math.round(datetime.getDate() / 1000)).toBe(Math.round(Date.now() / 1000));
+    });
+  });
+
+  describe('getYYYYMMDD', () => {
+    const tests = [
+      [1582299098000, undefined, '2020-02-21'],
+      [1585299098000, undefined, '2020-03-27'],
+      [1582299098000, '', '20200221'],
+      [1582299098000, '/', '2020/02/21'],
+      [-1000, undefined, '1969-12-31']
+    ];
+    each(tests).test('when passed date %d and delimiter "%s", it returns "%s"', (date, sep, expected) => {
+      expect(datetime.getYYYYMMDD(date, sep)).toBe(expected);
+    });
+  });
+
+  describe('isDateBefore', () => {
+    const tests = [
+      [1582299098000, 1582299098000, false],
+      [1582299098000, 1585299098000, true],
+      [1584299041000, 1584299541000, false],
+      [1584230399000, 1584230410000, true],
+      [1584230400000, 1584230410000, false]
+    ];
+    each(tests).test('when passed date %d and date %d, it returns %s', (a, b, expected) => {
+      expect(datetime.isDateBefore(a, b)).toBe(expected);
+    });
+  });
+});

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -28,15 +28,13 @@ async function fetch(url, type, date) {
     // This data probably has its own timeseries in it
     // Use local cache, assumed to be recent
     cachePath = 'cache';
-  }
-  else {
+  } else {
     if (!date && process.env['SCRAPE_DATE']) {
       date = process.env['SCRAPE_DATE'];
+    } else if (!date) {
+      date = datetime.getDate();
     }
-    else if (!date) {
-      date = datetime.getYYYYMD();
-    }
-    cachePath = path.join('coronadatascraper-cache', date);
+    cachePath = path.join('coronadatascraper-cache', datetime.getYYYYMMDD(date));
   }
 
   let urlHash = transform.hash(url);
@@ -50,12 +48,10 @@ async function fetch(url, type, date) {
   if (await fs.exists(filePath)) {
     console.log('  ⚡️ Loading data for %s from %s', url, filePath);
     body = await fs.readFile(filePath);
-  }
-  else if (date && datetime.dateIsBefore(new Date(date), datetime.getDate())) {
+  } else if (date && datetime.isDateBefore(date, datetime.getDate())) {
     console.log('  ⚠️  Cannot go back in time to get %s, no cache present', url);
     body = '';
-  }
-  else {
+  } else {
     console.log('  🚦  Loading data for %s from server', url);
     let response = await needle('get', url);
     body = response.body.toString();
@@ -93,16 +89,19 @@ function csv(url, date) {
   return new Promise(async (resolve, reject) => {
     let body = await fetch(url, 'csv', date);
 
-    csvParse(body, {
-      columns: true
-    }, function(err, output) {
-      if (err) {
-        reject(err);
+    csvParse(
+      body,
+      {
+        columns: true
+      },
+      function(err, output) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output);
+        }
       }
-      else {
-        resolve(output);
-      }
-    });
+    );
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "@babel/preset-env": "^7.8.7",
     "babel-jest": "^25.1.0",
     "jest": "^25.1.0"
+  },
+  "engines": {
+    "node": ">=13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gh-pages": "^2.2.0",
     "jest-each": "^25.1.0",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.28",
     "needle": "^2.3.3",
     "puppeteer": "^2.1.1",
     "yargs": "^15.3.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "editorconfig": "^0.15.3",
     "gh-pages": "^2.2.0",
     "jest-each": "^25.1.0",
+    "moment": "^2.24.0",
     "needle": "^2.3.3",
     "puppeteer": "^2.1.1",
     "yargs": "^15.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4483,6 +4483,11 @@ mkdirp@0.5.1, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 monotone-convex-hull-2d@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz#47f5daeadf3c4afd37764baa1aa8787a40eee08c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4483,7 +4483,14 @@ mkdirp@0.5.1, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.24.0:
+moment-timezone@^0.5.28:
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
+  integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
This PR ensures all dates used are in the PST timezone, and adds associated tests to ensure the behaviour of these functions is correct.

Closes #50 

Would recommend testing it locally to make sure caching is still working as intended before merging.