### PR TITLE
Update Ventura & Santa Cruz County

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ This gets you the latest scrapers, as well as the cache so we're not hammering s
 git pull upstream master --recurse-submodules
 ```
 
+Note: If you are encountering issues updating a submodule such as `Could not access submodule`, you may need to update your fork using:
+```
+git submodule update --init --recursive
+```
+
 ### Re-generating old data
 
 To re-generate old data from cache (or timeseries), run:

--- a/scrapers.js
+++ b/scrapers.js
@@ -865,18 +865,23 @@ let scrapers = [
     state: 'CA',
     country: 'USA',
     url: 'https://www.sccgov.org/sites/phd/DiseaseInformation/novel-coronavirus/Pages/home.aspx',
-    // Error: page needs JavaScript
-    _scraper: async function() {
-      let cases;
+
+    scraper: async function() {
+      // Santa Clara County uses JavaScript to parse JSON data into an HTML table. We cannot read
+      // this table directly without the DOM so we regex parse the JSON data.
+
       let $ = await fetch.page(this.url);
+      let scriptData = $('script:contains("Total_Confirmed_Cases")')[0].children[0].data;
 
-      let $table = $('.sccgov-responsive-table');
+      let regExp = /\[.*\]/;
+      let data = JSON.parse(regExp.exec(scriptData))[0];
 
-      let $cell = $table.find('.sccgov-responsive-table-cell').first();
-      cases = parse.number($cell.text());
+      let cases = parse.number(data['Total_Confirmed_Cases']);
+      let deaths = parse.number(data['Deaths']);
 
       return {
-        cases: cases
+        cases: cases,
+        deaths: deaths
       };
     }
   },

--- a/scrapers.js
+++ b/scrapers.js
@@ -851,9 +851,9 @@ let scrapers = [
       let cases;
       let $ = await fetch.page(this.url);
 
-      let $h1 = $('p:contains("Total Confirmed Cases")').nextAll('h1');
+      let $h2 = $('p:contains("Total Confirmed Cases")').nextAll('h2');
 
-      cases = parse.number($h1.text());
+      cases = parse.number($h2.text());
 
       return {
         cases: cases

--- a/scrapers.js
+++ b/scrapers.js
@@ -1159,23 +1159,25 @@ let scrapers = [
         $('.count-subject:contains("Positive travel-related case")')
           .closest('.hb-counter')
           .find('.count-number')
-          .text()
+          .attr('data-from')
       );
       cases += parse.number(
         $('.count-subject:contains("Presumptive Positive")')
           .closest('.hb-counter')
           .find('.count-number')
-          .text()
+          .attr('data-from')
+      );
+
+      let tested = parse.number(
+        $('.count-subject:contains("People tested")')
+          .closest('.hb-counter')
+          .find('.count-number')
+          .attr('data-from')
       );
 
       return {
         cases: cases,
-        tested: parse.number(
-          $('.count-subject:contains("People tested")')
-            .closest('.hb-counter')
-            .find('.count-number')
-            .text()
-        )
+        tested: tested
       };
     }
   },


### PR DESCRIPTION
This PR updates Ventura and Santa Cruz County. Santa Cruz county changed its formatting from H1 to H2 tag object. Ventura County had an issue with JS not populating the count text, however the counts are available in the the data-from or data-to attributes.