### PR TITLE
Map Congo (Kinshasa) to COD instead of COG

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -10,7 +10,7 @@ let countryCodes = JSON.parse(fs.readFileSync(path.join('coronavirus-data-source
   Override some incorrect country names
 */
 let countryMap = {
-  'Congo (Kinshasa)': 'Congo',
+  'Congo (Kinshasa)': 'Congo, Democratic Republic of the',
   "Cote d'Ivoire": "Côte d'Ivoire",
   'Russia': 'Russian Federation',
   'Vietnam': 'Viet Nam',


### PR DESCRIPTION
Congo-Kinshasa is the Democratic Republic of the Congo, which has three-letter code COD, while Congo is the different Republic of the Congo, which has three-letter code COG.