### PR TITLE
Use HTTPS for cache submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/lazd/coronavirus-data-sources.git
 [submodule "coronadatascraper-cache"]
 	path = coronadatascraper-cache
-	url = git@github.com:lazd/coronadatascraper-cache.git
+	url = https://github.com/lazd/coronadatascraper-cache.git


### PR DESCRIPTION
This allows cloning with submodules without SSH. (`git submodule sync` will be needed to update the URL.)

Edit: This would conflict with updating the cache repository automatically using the submodule, but that seems best done with a separate SSH clone.