### PR TITLE
Add coronavirus.idaho.gov scraper

### DIFF
--- a/scrapers.js
+++ b/scrapers.js
@@ -34,7 +34,7 @@ let scrapers = [
       let testedPublic = $('td:contains("tested through the Idaho Bureau of Lab") + td').first().html();
       
       return {
-        cases,
+        cases: parse.number(cases),
         tested: parse.number(testedPrivate) + parse.number(testedPublic)
       }
     }

--- a/scrapers.js
+++ b/scrapers.js
@@ -24,6 +24,22 @@ import * as fs from './lib/fs.js';
 
 let scrapers = [
   {
+    state: 'ID',
+    country: 'USA',
+    url: 'https://coronavirus.idaho.gov/',
+    scraper: async function() {
+      let $ = await fetch.page(this.url)
+      let cases = $('td:contains("Number of lab-confirmed COVID-19 cases") + td').first().html();
+      let testedPrivate = $('td:contains("tested through commercial laboratories") + td').first().html();
+      let testedPublic = $('td:contains("tested through the Idaho Bureau of Lab") + td').first().html();
+      
+      return {
+        cases,
+        tested: parse.number(testedPrivate) + parse.number(testedPublic)
+      }
+    }
+  },
+  {
     state: 'AZ',
     country: 'USA',
     url: 'https://tableau.azdhs.gov/views/COVID-19Dashboard/COVID-19table?:isGuestRedirectFromVizportal=y&:embed=y',


### PR DESCRIPTION
Adds a scraper for Idaho's stats table. Looks like they picked up their first cases recently.

Includes # of cases and the sum of the two rows with # of tested.

PS thank you for starting up this project! I'd love to contribute in any way possible, let me know if there's anything high-priority you're looking for help on.