### PR TITLE
Add scraper for United Kingdom

### DIFF
--- a/scrapers.js
+++ b/scrapers.js
@@ -380,6 +380,24 @@ let scrapers = [
     }
   },
   {
+    country: 'GBR',
+    url: 'https://www.arcgis.com/sharing/rest/content/items/b684319181f94875a6879bbc833ca3a6/data',
+    scraper: async function() {
+      let data = await fetch.csv(this.url);
+
+      let counties = [];
+      for (let utla of data) {
+        let name = parse.string(utla.GSS_NM);
+        counties.push({
+          county: name,
+          cases: parse.number(utla.TotalCases)
+        });
+      }
+
+      return counties;
+    }
+  },
+  {
     state: 'MS',
     country: 'USA',
     url: 'https://msdh.ms.gov/msdhsite/_static/14,0,420.html',


### PR DESCRIPTION
This uses [the cases table](https://www.arcgis.com/home/item.html?id=b684319181f94875a6879bbc833ca3a6) for upper-tier local authorities with cases [reported to Public Health England](https://www.gov.uk/government/publications/covid-19-track-coronavirus-cases). Recoveries and deaths are not included and case counts are not summed since the sum is lower than the reported total case count:

> Total number for England may not match UTLA and NHS Regions number as some cases are awaiting geographical information.

Also no features since [the relevant dataset](https://data.gov.uk/dataset/6ee49b1e-0f4d-4079-90f4-b626e36d2035/lower-tier-local-authority-to-upper-tier-local-authority-april-2019-lookup-in-england-and-wales) doesn’t have geometry and refers to the Open Geography Portal instead.