### PR TITLE
Calculate ratings for datasources based on objective criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # coronadatascraper
 > A scraper that pulls coronavirus case data from verified sources.
 
+This project exists to pull county-level data for COVID-19 from verified, high-quality sources.
+
+Every piece of data produced includes the URL where the data was sourced from as well as a rating of the source's technical quality (completeness, machine readability, best practices -- not accuracy).
+
 ## Where's the data?
 
 http://blog.lazd.net/coronadatascraper/
@@ -100,6 +104,11 @@ Add the following directly to the scraper object if the data you're pulling in i
 * `county` - The county or parish
 * `state` - The state, province, or region
 * `country` - [ISO 3166-1 alpha-3 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)
+* `type` - on of `json`, `csv`, `table`, `list`, `paragraph`, `pdf`, `image`. assumes `list` if `undefined`.
+* `timeseries` - `true` if this source provides timeseries data, `false` or `undefined` if it only provides the latest data
+* `headless` - whether this source requires a headless browser to scrape
+* `ssl` - `true` or `undefined` if this host has a valid SSL certificate chain, `false` if not
+* `priority` - any number (negative or positive). `0` is default, higher priority wins if duplicate data is present, ties are broken by rating
 
 Your scraper should return a `data` object, or an array of objects, with some of the following information:
 
@@ -258,6 +267,20 @@ Additional data is welcome.
 #### 3. Presumptive cases are considered confirmed
 
 In keeping with other datasets, presumptive cases should be considered part of the case total.
+
+### Source rating
+
+Sources are rated based on:
+
+1. **How hard is it to read?** - `csv` and `json` give best scores, with `table` right behind it, with `list` and `paragraph` worse. `pdf` gets no points, and `image` gets negative points.
+2. **Timeseries?** - Sources score points if they provide a timeseries.
+3. **Completeness** - Sources get points for having `cases`, `tested`, `deaths`, `recovered`, `country`, `state`, `county`, and `city`.
+4. **SSL** - Sources get points for serving over ssl
+5. **Headless?** - Sources get docked points if they require a headless scraper
+
+The maximium rating for a source is 1, the minimum is near 0. See [`lib/transform.calcuateRating`](blob/master/lib/transform.js) for the exact algorithm.
+
+All data in the output includes the `url` and the `rating` of the source.
 
 ## License
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -218,6 +218,74 @@ function getGrowthfactor(casesToday, casesYesterday) {
   return growthFactor;
 }
 
+/*
+  Calculate the rating of a source
+    info.granularity - the granularity of the data
+    info.type - the way the source presents data (see below)
+    info.timeseries - true if timeseries provided, false if just latest
+    info.fields -  array of fields available from source
+*/
+function calculateRating(info) {
+  let easeOfRead = {
+    'json': 1,
+    'csv': 1,
+    'table': 0.75,
+    'list': 0.5,
+    'paragraph': 0.25,
+    'pdf': 0,
+    'image': -1
+  };
+
+  let timeseries = {
+    'false': 0, // everyone's got the latest
+    'true': 1 // but timeseries is worth a lot
+  };
+
+  let completeness = {
+    cases: 0.5,
+    tested: 1,
+    deaths: 1,
+    recovered: 1,
+    country: 0.5,
+    state: 0.5,
+    county: 1,
+    city: 0.5
+  };
+
+  // Give credit for completeness
+  let rating = 0;
+  for (let field in completeness) {
+    if (info[field] !== null && info[field] !== undefined) {
+      rating += completeness[field];
+    }
+  }
+
+  // Auto-detect JSON and CSV
+  if (!info.type && easeOfRead[path.extname(info.url).substr(1)]) {
+    info.type = path.extname(info.url).substr(1);
+  }
+
+  let ssl = false;
+  if (info.url.substr(0, 5) === 'https' && info.ssl != false) {
+    rating += 0.25;
+  }
+
+  // Dock some points if we have to go headless
+  if (info.blocked) {
+    rating -= 0.5;
+  }
+
+  // Assume it's a list
+  rating += easeOfRead[info.type || 'list'];
+
+  rating += timeseries[!!info.timeseries];
+
+  // Calculate highest possible rating
+  let possible = Object.values(completeness).reduce((a, v) => a + v, 0) + timeseries[true] + Object.values(easeOfRead).sort().pop();
+
+  return rating / possible;
+}
+
 export {
   objectToArray,
   addCounty,
@@ -231,4 +299,5 @@ export {
   usStates,
   getPriority,
   getGrowthfactor,
+  calculateRating,
 };

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -271,7 +271,7 @@ function calculateRating(info) {
   }
 
   // Dock some points if we have to go headless
-  if (info.blocked) {
+  if (info.headless) {
     rating -= 0.5;
   }
 

--- a/scrapers.js
+++ b/scrapers.js
@@ -44,6 +44,7 @@ let scrapers = [
     url: 'https://opendata.arcgis.com/datasets/d14de7e28b0448ab82eb36d6f25b1ea1_0.csv',
     country: 'USA',
     state: 'IN',
+    timeseries: false,
     _countyMap: {
       'Verm.': 'Vermillion',
       'Vander.': 'Vanderburgh',
@@ -114,6 +115,7 @@ let scrapers = [
   {
     country: 'Canada',
     url: 'https://www.canada.ca/en/public-health/services/diseases/2019-novel-coronavirus-infection.html',
+    type: 'table',
     _reject: [
       {
         state: 'Repatriated travellers'
@@ -149,6 +151,7 @@ let scrapers = [
   },
   {
     url: 'https://github.com/CSSEGISandData/COVID-19',
+    timeseries: true,
     _priority: -1,
     _urls: {
       cases: 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv',
@@ -335,6 +338,7 @@ let scrapers = [
     country: 'CHE',
     county: 'Zurich',
     url: 'https://raw.githubusercontent.com/openZH/covid_19/master/COVID19_Fallzahlen_Kanton_ZH_total.csv',
+    timeseries: true,
     scraper: async function() {
       let data = await fetch.csv(this.url, false);
 
@@ -359,6 +363,7 @@ let scrapers = [
   {
     country: 'ITA',
     url: 'https://raw.githubusercontent.com/pcm-dpc/COVID-19/master/dati-regioni/dpc-covid19-ita-regioni.csv',
+    timeseries: true,
     _regionMap: {
       'P.A. Trento': 'Trento',
       'Emilia Romagna': 'Emilia-Romagna',
@@ -412,6 +417,7 @@ let scrapers = [
     state: 'MS',
     country: 'USA',
     url: 'https://msdh.ms.gov/msdhsite/_static/14,0,420.html',
+    type: 'table',
     scraper: async function() {
       let $ = await fetch.page(this.url);
 
@@ -502,6 +508,7 @@ let scrapers = [
     state: 'AL',
     country: 'USA',
     url: 'http://www.alabamapublichealth.gov/infectiousdiseases/2019-coronavirus.html',
+    type: 'table',
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -602,6 +609,7 @@ let scrapers = [
     state: 'OR',
     country: 'USA',
     url: 'https://www.oregon.gov/oha/PH/DISEASESCONDITIONS/DISEASESAZ/Pages/emerging-respiratory-infections.aspx',
+    type: 'table',
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -635,6 +643,7 @@ let scrapers = [
       let counties = [];
       if (datetime.scrapeDateIsBefore('2020-3-14')) {
         this.url = 'http://ldh.la.gov/Coronavirus/';
+        this.type = 'table';
 
         let $ = await fetch.page(this.url);
 
@@ -665,6 +674,8 @@ let scrapers = [
       }
       else {
         this.url = 'https://opendata.arcgis.com/datasets/cba425c2e5b8421c88827dc0ec8c663b_0.csv';
+        this.type = 'csv';
+
         // Use the new map
         let data = await fetch.csv(this.url);
 
@@ -693,7 +704,8 @@ let scrapers = [
     state: 'IA',
     country: 'USA',
     url: 'https://idph.iowa.gov/emerging-health-issues/novel-coronavirus',
-    // Incapsula blocking request
+    type: 'table',
+    headless: true, // Incapsula blocking request
     scraper: async function() {
       let counties = [];
       let $ = await fetch.headless(this.url);
@@ -724,7 +736,8 @@ let scrapers = [
     state: 'TX',
     country: 'USA',
     url: 'https://www.dshs.state.tx.us/news/updates.shtm',
-    // Error: unable to verify the first certificate
+    type: 'table',
+    ssl: false, // Error: unable to verify the first certificate
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -780,6 +793,7 @@ let scrapers = [
     state: 'FL',
     country: 'USA',
     url: 'http://www.floridahealth.gov/diseases-and-conditions/COVID-19/index.html',
+    type: 'table',
     _priority: 1,
     scraper: async function() {
       let counties = {};
@@ -818,6 +832,7 @@ let scrapers = [
     state: 'NY',
     country: 'USA',
     url: 'https://www.health.ny.gov/diseases/communicable/coronavirus/',
+    type: 'table',
     _countyMap: {
       // This is totally wrong, but otherwise we need less granular GeoJSON
       'New York City': 'New York County',
@@ -850,6 +865,8 @@ let scrapers = [
     state: 'WA',
     country: 'USA',
     url: 'https://www.doh.wa.gov/Emergencies/Coronavirus',
+    type: 'table',
+    headless: true,
     scraper: async function() {
       let counties = [];
       let $ = await fetch.headless(this.url);
@@ -1464,6 +1481,7 @@ let scrapers = [
     state: 'WI',
     country: 'USA',
     url: 'https://www.dhs.wisconsin.gov/outbreaks/index.htm',
+    type: 'table',
     scraper: async function() {
       let $ = await fetch.page(this.url);
       let counties = [];
@@ -1483,6 +1501,7 @@ let scrapers = [
     state: 'SD',
     country: 'USA',
     url: 'https://doh.sd.gov/news/Coronavirus.aspx#SD',
+    type: 'table',
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -1504,6 +1523,7 @@ let scrapers = [
     state: 'UT',
     country: 'USA',
     url: 'https://coronavirus.utah.gov/latest/',
+    type: 'table',
     scraper: async function () {
       let $ = await fetch.page(this.url);
       let counties = [];
@@ -1549,6 +1569,7 @@ let scrapers = [
     state: 'TN',
     country: 'USA',
     url: 'https://www.tn.gov/health/cedep/ncov.html',
+    type: 'table',
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -1619,6 +1640,7 @@ let scrapers = [
     state: 'MD',
     country: 'USA',
     url: 'http://opendata.arcgis.com/datasets/ca77764e722c442986ef6514da88411c_0.csv',
+    type: 'csv',
     scraper: async function() {
       let data = await fetch.csv(this.url);
 

--- a/scrapers.js
+++ b/scrapers.js
@@ -542,6 +542,7 @@ let scrapers = [
     state: 'CO',
     country: 'USA',
     url: 'https://docs.google.com/document/d/e/2PACX-1vRSxDeeJEaDxir0cCd9Sfji8ZPKzNaCPZnvRCbG63Oa1ztz4B4r7xG_wsoC9ucd_ei3--Pz7UD50yQD/pub',
+    type: 'list',
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -1547,6 +1548,7 @@ let scrapers = [
     state: 'PA',
     country: 'USA',
     url: 'https://www.health.pa.gov/topics/disease/Pages/Coronavirus.aspx',
+    type: 'list',
     scraper: async function () {
       let counties = [];
       let $ = await fetch.page(this.url);
@@ -1615,6 +1617,7 @@ let scrapers = [
     state: 'CT',
     country: 'USA',
     url: 'https://portal.ct.gov/Coronavirus',
+    type: 'list',
     scraper: async function() {
       let counties = [];
       let $ = await fetch.page(this.url);

--- a/tasks/scrapeData.js
+++ b/tasks/scrapeData.js
@@ -111,10 +111,11 @@ async function scrape() {
     let locationName = transform.getName(location);
     let otherLocation = seenLocations[locationName];
     if (otherLocation) {
-      let thisPriority = transform.getPriority(location);
-      let otherPriority = transform.getPriority(otherLocation);
+      // Take rating into account to break ties
+      let thisPriority = transform.getPriority(location) + (location.rating / 2);
+      let otherPriority = transform.getPriority(otherLocation) + (otherLocation.rating / 2);
       if (otherPriority === thisPriority) {
-        console.log('⚠️  %s: Equal priority sources choosing %s (%d) over %s (%d)', locationName, location.url, thisPriority, otherLocation.url, otherPriority);
+        console.log('⚠️  %s: Equal priority sources choosing %s (%d) over %s (%d) arbitrarily', locationName, location.url, thisPriority, otherLocation.url, otherPriority);
         // Kill the other location
         locations.splice(locations.indexOf(otherLocation), 1);
         deDuped++;

--- a/tasks/scrapeData.js
+++ b/tasks/scrapeData.js
@@ -9,6 +9,9 @@ function addLocationToData(data, location) {
 
   delete data.scraper;
 
+  // Add rating
+  data.rating = transform.calculateRating(data);
+
   return data;
 }
 


### PR DESCRIPTION
Closes #82 

This PR adds rating calculation based on available fields, data type, encryption, whether we have to access it headless, and whether it has time series data. The maximum rating is 1.

In addition, it uses the calculated rating to break ties when deduping data that has identical priorities.