### PR TITLE
feat: add scraper for DEU (Germany)

### DIFF
--- a/scrapers.js
+++ b/scrapers.js
@@ -27,6 +27,23 @@ const UNASSIGNED = '(unassigned)';
 
 const scrapers = [
   {
+    country: 'DEU',
+    url: 'https://covid19-germany.appspot.com/now',
+    type: 'json',
+    ssl: true,
+    async scraper() {
+      const data = await fetch.json(this.url);
+      return {
+        country: 'DEU',
+        cases: data.current_totals.cases,
+        deaths: data.current_totals.deaths,
+        recovered: data.current_totals.recovered,
+        coordinates: [9.0, 51.0],
+        population: 83 * 10 ** 6
+      };
+    }
+  },
+  {
     state: 'AZ',
     country: 'USA',
     url: 'https://tableau.azdhs.gov/views/COVID-19Dashboard/COVID-19table?:isGuestRedirectFromVizportal=y&:embed=y',


### PR DESCRIPTION
Hey!

The README patch is just a minor proposal, feel free to say if you don't like that.

I have tried to test the scraper:
```
$ yarn start --location "DEU"
yarn run v1.22.4
$ NODE_OPTIONS='--insecure-http-parser' node cli.js --location DEU
(node:15641) ExperimentalWarning: The ESM module loader is experimental.
⏳ Scraping data for today...
  🐢 Cache miss for https://covid19-germany.appspot.com/now at coronadatascraper-cache/2020-3-17/38f8f7262afb9fab969c26940d40bca8.json
  🚦  Loading data for https://covid19-germany.appspot.com/now from server
(node:15641) Warning: Using insecure HTTP parsing
  ⚡️ Cache hit for https://opendata.arcgis.com/datasets/d14de7e28b0448ab82eb36d6f25b1ea1_0.csv from coronadatascraper-cache/2020-3-17/ea58672b23e340fbf8f209b7af40173c.csv
...
```
Seems to have worked in the sense that it did not error out.

