### PR TITLE
Updated Mono County, CA to include tests

### DIFF
--- a/scrapers.js
+++ b/scrapers.js
@@ -1816,20 +1816,48 @@ const scrapers = [
     state: 'CA',
     country: 'USA',
     url: 'https://monocovid19-monomammoth.hub.arcgis.com/',
-    async scraper() {
-      const $ = await fetch.headless(this.url);
+    scraper: {
+      '0': async function() {
+        const $ = await fetch.headless(this.url);
 
-      const cases = parse.number(
-        $('h4:contains("POSITIVE")')
-          .first()
-          .parent()
-          .next('h3')
-          .text()
-      );
+        const cases = parse.number(
+          $('h4:contains("POSITIVE")')
+            .first()
+            .parent()
+            .next('h3')
+            .text()
+        );
 
-      return {
-        cases
-      };
+        return {
+          cases
+        };
+      },
+      '2020-3-19': async function() {
+        const $ = await fetch.headless(this.url);
+
+        const cases = parse.number(
+          $('h4:contains("POSITIVECASES")')
+            .first()
+            .parent()
+            .find('h3')
+            .first()
+            .text()
+        );
+
+        const tested = parse.number(
+          $('h4:contains("TESTSGIVEN")')
+            .first()
+            .parent()
+            .find('h3')
+            .first()
+            .text()
+        );
+
+        return {
+          cases,
+          tested
+        };
+      }
     }
   },
   {


### PR DESCRIPTION
This fixes the Mono County to correctly pull the right cases. It was reporting 0 however the number of cases is also 0 so no change to the data. I added the number of tests given. This was not available previously and is how I recognized the issue.