### PR TITLE
Fix ventura

### DIFF
--- a/scrapers.js
+++ b/scrapers.js
@@ -1894,7 +1894,7 @@ const scrapers = [
             .find('.count-number')
             .attr('data-from')
         );
-      } else if (datetime.scrapeDateIsBefore('2020-3-17')) {
+      } else if (datetime.scrapeDateIsBefore('2020-3-18')) {
         cases += parse.number(
           $('td:contains("Positive cases")')
             .closest('table')

--- a/scrapers.js
+++ b/scrapers.js
@@ -1894,7 +1894,7 @@ const scrapers = [
             .find('.count-number')
             .attr('data-from')
         );
-      } else {
+      } else if (datetime.scrapeDateIsBefore('2020-3-17')) {
         cases += parse.number(
           $('td:contains("Positive cases")')
             .closest('table')
@@ -1913,6 +1913,13 @@ const scrapers = [
         tested = parse.number(
           $('td:contains("People tested")')
             .closest('table')
+            .find('td')
+            .first()
+            .text()
+        );
+      } else {
+        cases += parse.number(
+          $('tr.trFirstRow')
             .find('td')
             .first()
             .text()


### PR DESCRIPTION
Updated the scraper for Ventura, CA. The page layout seems to have changed on 3/18. The old scraper started returning 0 on that date. This version is pulling the currently correct value of 13.