### PR TITLE
fix: use forward slashes in glob patterns

### DIFF
--- a/src/events/crawler/tasks/fetchSources.js
+++ b/src/events/crawler/tasks/fetchSources.js
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 export default async args => {
   console.log(`⏳ Fetching scrapers`);
-  const scrapers = join(__dirname, '..', 'scrapers', '**', '*.js');
+  const scrapers = join(__dirname, '..', 'scrapers', '**', '*.js').replace(/\\/g, '/');
   let filePaths = await fastGlob([scrapers]);
   filePaths = filePaths.filter(file => !file.endsWith('.test.js'));
   const sources = await Promise.all(filePaths.map(filePath => import(filePath))).then(modules => [


### PR DESCRIPTION
This is needed to allow developers working on Windows to run the scraper locally. 

From https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows :

> Always use forward-slashes in glob expressions (patterns and [`ignore`](#ignore) option). 
> Use backslashes for escaping characters. With the [`cwd`](#cwd) option use a convenient format.
> 
> **Bad**
> 
> ```ts
> [
> 	'directory\\*',
> 	path.join(process.cwd(), '**')
> ]
> ```
> 
> **Good**
> 
> ```ts
> [
> 	'directory/*',
> 	path.join(process.cwd(), '**').replace(/\\/g, '/')
> ]
> ```
> 

I've tested this on Windows and Ubuntu. 
