### PR TITLE
Quieter eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,14 @@
 {
   "extends": ["airbnb-base", "plugin:jest/recommended", "plugin:jest/style", "plugin:prettier/recommended"],
-  "parser": "babel-eslint",
   "ignorePatterns": ["dist/"],
+  "parser": "babel-eslint",
   "rules": {
-    "jest/expect-expect": "off",
-    "jest/no-standalone-expect": "off",
     "consistent-return": "off",
     "func-names": "off",
+    "import/extensions": ["error", "ignorePackages"],
+    "jest/expect-expect": "off",
+    "jest/no-standalone-expect": "off",
+    "jest/no-try-expect": "off",
     "no-async-promise-executor": "off",
     "no-await-in-loop": "off",
     "no-console": "off",
@@ -16,8 +18,6 @@
     "no-plusplus": "off",
     "no-restricted-syntax": "off",
     "no-shadow": "off",
-    "import/extensions": ["error", "ignorePackages"],
-    "no-underscore-dangle": "off",
-    "jest/no-try-expect": "off"
+    "no-underscore-dangle": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,18 +3,23 @@
   "parser": "babel-eslint",
   "ignorePatterns": ["dist/"],
   "rules": {
-    "jest/no-standalone-expect": "warn",
-    "no-async-promise-executor": "warn",
-    "no-await-in-loop": "warn",
+    "jest/no-expect-expect": "off",
+    "jest/no-standalone-expect": "off",
+    "consistent-return": "off",
+    "func-names": "off",
+    "no-async-promise-executor": "off",
+    "no-await-in-loop": "off",
     "no-console": "off",
-    "no-continue": "warn",
-    "no-labels": "warn",
-    "no-param-reassign": "warn",
+    "no-continue": "off",
+    "no-labels": "off",
+    "no-param-reassign": "off",
     "no-plusplus": "off",
     "no-restricted-syntax": "off",
-    "no-shadow": "warn",
+    "no-shadow": "off",
     "import/extensions": ["error", "ignorePackages"],
     "no-underscore-dangle": "off",
     "jest/no-try-expect": "off"
   }
 }
+
+

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "parser": "babel-eslint",
   "ignorePatterns": ["dist/"],
   "rules": {
-    "jest/no-expect-expect": "off",
+    "jest/expect-expect": "off",
     "jest/no-standalone-expect": "off",
     "consistent-return": "off",
     "func-names": "off",
@@ -21,5 +21,3 @@
     "jest/no-try-expect": "off"
   }
 }
-
-

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "timeseries": "node src/events/crawler/timeseries.js",
     "update": "npm run updateModules && rm -rf cache/* && npm run start",
     "updateModules": "git submodule update --remote",
-    "pretty": "prettier --write --single-quote '**/*.js'"
+    "pretty": "prettier --write '**/*.js'"
   },
   "dependencies": {
     "@adobe/focus-ring-polyfill": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,5 +85,10 @@
     "*.js": [
       "eslint --fix"
     ]
+  },
+  "prettier": {
+    "printWidth": 120,
+    "semi": true,
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
This PR turns off warnings for es-lint issues that we're currently disregarding. 

- consistent-return
- func-names
- jest/expect-expect
- jest/no-standalone-expect
- jest/no-try-expect
- no-async-promise-executor
- no-await-in-loop
- no-console
- no-continue
- no-labels
- no-param-reassign
- no-plusplus
- no-restricted-syntax
- no-shadow
- no-underscore-dangle

I don't have strong opinions about any of these rules - some are good practice, some seem a little arbitrary, and some we probably never intend to follow.

 Either way, the current functioning of the site depends on code that breaks these rules. That code could be refactored, but without better test coverage it's not worth the risk of inadvertently breaking the site. 

I've also removed `git-add` from the `lint-staged` config, as per the Husky warning advising that it's unnecessary.

Finally, I've added the prettier config to package.json, and removed a now-redundant `--single-quote` flag from the `pretty` task. 

Hopefully this will improve the DX for contributors by eliminating unhelpful noise. 
