### PR TITLE
fix: AUS Victoria

### DIFF
--- a/src/events/crawler/scrapers/AUS/VIC/index.js
+++ b/src/events/crawler/scrapers/AUS/VIC/index.js
@@ -22,7 +22,7 @@ const scraper = {
     const currentArticleUrl = $anchor.attr('href');
     const $currentArticlePage = await fetch.page(`https://www.dhhs.vic.gov.au${currentArticleUrl}`);
     const paragraph = $currentArticlePage('.page-content p:first-of-type').text();
-    const { casesString } = paragraph.match(/cases in Victoria to (?<casesString>\d+)./).groups;
+    const { casesString } = paragraph.match(/cases in Victoria .* (?<casesString>\d+)./).groups;
     return {
       state: scraper.state,
       cases: parse.number(casesString)

--- a/src/events/crawler/scrapers/AUS/VIC/index.js
+++ b/src/events/crawler/scrapers/AUS/VIC/index.js
@@ -22,7 +22,7 @@ const scraper = {
     const currentArticleUrl = $anchor.attr('href');
     const $currentArticlePage = await fetch.page(`https://www.dhhs.vic.gov.au${currentArticleUrl}`);
     const paragraph = $currentArticlePage('.page-content p:first-of-type').text();
-    const { casesString } = paragraph.match(/cases in Victoria .* (?<casesString>\d+)./).groups;
+    const { casesString } = paragraph.match(/cases in Victoria \w* (?<casesString>\d+)./).groups;
     return {
       state: scraper.state,
       cases: parse.number(casesString)


### PR DESCRIPTION
For Victoria, AUS, the 03-25 press release has the word `is` instead of `to` before the number of cases, which breaks the regex