### PR TITLE
remove state-level scraper for VIC because their data is unusable, fall back to AUS

### DIFF
--- a/src/shared/scrapers/AUS/VIC/index.js
+++ b/src/shared/scrapers/AUS/VIC/index.js
@@ -25,13 +25,17 @@ const scraper = {
       const paragraph = $currentArticlePage('.page-content p:first-of-type').text();
       const { casesString } = paragraph.match(/cases in Victoria \w* (?<casesString>\d+)./).groups;
       return {
+        state: this.state,
         cases: parse.number(casesString)
       };
     },
-    '2020-2-25': async function() {
-      return {
-        cases: 466
-      };
+    // Constantly changing free-text media release.
+    // They have a PowerBI dashboard at https://app.powerbi.com/view?r=eyJrIjoiODBmMmE3NWQtZWNlNC00OWRkLTk1NjYtMjM2YTY1MjI2NzdjIiwidCI6ImMwZTA2MDFmLTBmYWMtNDQ5Yy05Yzg4LWExMDRjNGViOWYyOCJ9
+    // No idea how to get the data out of that though.
+    // We've emailed them on 2020-03-28 to try to get a usable format.
+    // For now lets fall back to the AUS index scraper.
+    '2020-3-25': async function() {
+      return {};
     }
   }
 };


### PR DESCRIPTION
Victoria have a dashboard at https://app.powerbi.com/view?r=eyJrIjoiODBmMmE3NWQtZWNlNC00OWRkLTk1NjYtMjM2YTY1MjI2NzdjIiwidCI6ImMwZTA2MDFmLTBmYWMtNDQ5Yy05Yzg4LWExMDRjNGViOWYyOCJ9 that I can't scrape because its dynamic and the JSON is crazily structured and using some sort of auth.
They also have media releases that they keep changing the format of.

health.gov.au (AUS/index) has the same data anyway (sometimes slightly out of date), so I'm giving up on AUS/VIC until they can provide accessible data.