### PR TITLE
throw deprecated error for scrapers that cant give consistent format

### DIFF
--- a/scripts/statusSlackBot.js
+++ b/scripts/statusSlackBot.js
@@ -37,7 +37,7 @@ const generateReport = async report => {
 _Sources:_
 - *${sources.numSources}* sources
 - *${sources.errors.length}* invalid sources:
-${filteredScaperErrors.map(error => `  - ${error}`).join('\n')}`
+${sources.errors.map(error => `  - ${error}`).join('\n')}`
       }
     },
     {
@@ -51,7 +51,7 @@ _Scrapers:_
 - *${scrape.numStates}* states
 - *${scrape.numCountries}* countries
 - *${filteredScaperErrors.length}* scraper errors:
-${scrape.errors.map(error => `  - ${error.name}: ${error.err}`).join('\n')}`
+${filteredScaperErrors.map(error => `  - ${error.name}: ${error.err}`).join('\n')}`
       }
     },
     {

--- a/scripts/statusSlackBot.js
+++ b/scripts/statusSlackBot.js
@@ -37,7 +37,7 @@ const generateReport = async report => {
 _Sources:_
 - *${sources.numSources}* sources
 - *${sources.errors.length}* invalid sources:
-${sources.errors.map(error => `  - ${error}`).join('\n')}`
+${filteredScaperErrors.map(error => `  - ${error}`).join('\n')}`
       }
     },
     {

--- a/scripts/statusSlackBot.js
+++ b/scripts/statusSlackBot.js
@@ -19,6 +19,8 @@ const { argv } = yargs
 const generateReport = async report => {
   const { sources, scrape, findFeatures, findPopulation, validate } = report;
 
+  const filteredScaperErrors = scrape.errors.filter(error => error.type !== 'DeprecatedError');
+
   return [
     {
       type: 'section',
@@ -48,7 +50,7 @@ _Scrapers:_
 - *${scrape.numCounties}* counties
 - *${scrape.numStates}* states
 - *${scrape.numCountries}* countries
-- *${scrape.numErrors}* scraper errors:
+- *${filteredScaperErrors.length}* scraper errors:
 ${scrape.errors.map(error => `  - ${error.name}: ${error.err}`).join('\n')}`
       }
     },

--- a/src/events/crawler/scrape-data/run-scraper.js
+++ b/src/events/crawler/scrape-data/run-scraper.js
@@ -106,6 +106,7 @@ const runScrapers = async args => {
         errors.push({
           name: geography.getName(location),
           url: location.url,
+          type: err.name,
           err: err.toString()
         });
       }

--- a/src/shared/lib/errors.js
+++ b/src/shared/lib/errors.js
@@ -1,0 +1,11 @@
+/* eslint-disable import/prefer-default-export */
+
+export class DeprecatedError extends Error {
+  /**
+   * @param {string} message
+   */
+  constructor(message) {
+    super(message);
+    this.name = 'DeprecatedError';
+  }
+}

--- a/src/shared/scrapers/AUS/VIC/index.js
+++ b/src/shared/scrapers/AUS/VIC/index.js
@@ -1,5 +1,6 @@
-import * as parse from '../../../lib/parse.js';
+import { DeprecatedError } from '../../../lib/errors.js';
 import * as fetch from '../../../lib/fetch/index.js';
+import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
 
 const scraper = {
@@ -16,26 +17,25 @@ const scraper = {
   state: 'Victoria',
   type: 'paragraph',
   url: 'https://www.dhhs.vic.gov.au/media-hub-coronavirus-disease-covid-19',
-  scraper: {
-    '0': async function() {
-      const $ = await fetch.page(this.url);
-      const $anchor = $('.content ul li a:contains("Department of Health and Human Services media release - ")');
-      const currentArticleUrl = $anchor.attr('href');
-      const $currentArticlePage = await fetch.page(`https://www.dhhs.vic.gov.au${currentArticleUrl}`);
-      const paragraph = $currentArticlePage('.page-content p:first-of-type').text();
+  async scraper() {
+    const $ = await fetch.page(this.url);
+    const $anchor = $('.content ul li a:contains("Department of Health and Human Services media release - ")');
+    const currentArticleUrl = $anchor.attr('href');
+    const $currentArticlePage = await fetch.page(`https://www.dhhs.vic.gov.au${currentArticleUrl}`);
+    const paragraph = $currentArticlePage('.page-content p:first-of-type').text();
+    try {
       const { casesString } = paragraph.match(/cases in Victoria \w* (?<casesString>\d+)./).groups;
       return {
         state: this.state,
         cases: parse.number(casesString)
       };
-    },
-    // Constantly changing free-text media release.
-    // They have a PowerBI dashboard at https://app.powerbi.com/view?r=eyJrIjoiODBmMmE3NWQtZWNlNC00OWRkLTk1NjYtMjM2YTY1MjI2NzdjIiwidCI6ImMwZTA2MDFmLTBmYWMtNDQ5Yy05Yzg4LWExMDRjNGViOWYyOCJ9
-    // No idea how to get the data out of that though.
-    // We've emailed them on 2020-03-28 to try to get a usable format.
-    // For now lets fall back to the AUS index scraper.
-    '2020-3-25': async function() {
-      return {};
+    } catch (error) {
+      // Constantly changing free-text media release.
+      // They have a PowerBI dashboard at https://app.powerbi.com/view?r=eyJrIjoiODBmMmE3NWQtZWNlNC00OWRkLTk1NjYtMjM2YTY1MjI2NzdjIiwidCI6ImMwZTA2MDFmLTBmYWMtNDQ5Yy05Yzg4LWExMDRjNGViOWYyOCJ9
+      // No idea how to get the data out of that though.
+      // We've emailed them on 2020-03-28 to try to get a usable format.
+      // For now lets fall back to the AUS index scraper.
+      return new DeprecatedError('Victoria, AUS has no consistent format');
     }
   }
 };

--- a/src/shared/scrapers/AUS/VIC/index.js
+++ b/src/shared/scrapers/AUS/VIC/index.js
@@ -35,7 +35,7 @@ const scraper = {
       // No idea how to get the data out of that though.
       // We've emailed them on 2020-03-28 to try to get a usable format.
       // For now lets fall back to the AUS index scraper.
-      return new DeprecatedError('Victoria, AUS has no consistent format');
+      throw new DeprecatedError('Victoria, AUS has no consistent format');
     }
   }
 };

--- a/src/shared/scrapers/USA/CA/sonoma-county.js
+++ b/src/shared/scrapers/USA/CA/sonoma-county.js
@@ -15,9 +15,6 @@ const scraper = {
   async scraper() {
     const $ = await fetch.page(this.url);
     const $th = $('th:contains("Total in Sonoma County")');
-    if ($th.html() === null) {
-      throw new DeprecatedError('Could not find table');
-    }
     const $table = $th.closest('table');
     const $td = $table.find('td:last-child');
     const cases = parse.number($td.text());

--- a/src/shared/scrapers/USA/CA/sonoma-county.js
+++ b/src/shared/scrapers/USA/CA/sonoma-county.js
@@ -1,3 +1,4 @@
+import { DeprecatedError } from '../../../lib/errors.js';
 import * as fetch from '../../../lib/fetch/index.js';
 import * as parse from '../../../lib/parse.js';
 import maintainers from '../../../lib/maintainers.js';
@@ -14,6 +15,9 @@ const scraper = {
   async scraper() {
     const $ = await fetch.page(this.url);
     const $th = $('th:contains("Total in Sonoma County")');
+    if ($th.html() === null) {
+      throw new DeprecatedError('Could not find table');
+    }
     const $table = $th.closest('table');
     const $td = $table.find('td:last-child');
     const cases = parse.number($td.text());


### PR DESCRIPTION
As mentioned in https://github.com/lazd/coronadatascraper/pull/453 from @chunder @lazd .

@lazd Wheres the bit we need to catch and ignore this?

Is this the approach we want (allow scrapers to come-good-again if they again match the original format) or do we want to split it out into dates and just immediately throw the error after the first bad date?

(and if this is the implementation we want, is DeprecatedError semantically correct? Maybe InconsistentFormatError or something? )