### PR TITLE
Fix fresno county total cases

### DIFF
--- a/src/shared/scrapers/USA/CA/fresno-county.js
+++ b/src/shared/scrapers/USA/CA/fresno-county.js
@@ -14,7 +14,13 @@ const scraper = {
   async scraper() {
     const $ = await fetch.page(this.url);
     return {
-      cases: parse.number($('li:contains("Total cases")').text()),
+      cases: parse.number(
+        $('li:contains("Total cases")')
+          .children()
+          .remove()
+          .end()
+          .text()
+      ),
       deaths: parse.number($('li:contains("Total deaths")').text())
     };
   }


### PR DESCRIPTION
Currently the Fresno county scraper is concatenating Total cases and Travel related cases to report 3116 cases instead of 31. This fixes the issue. 