### PR TITLE
Harden AUS scrapers, add new scraper for completely changed ACT

### DIFF
--- a/src/shared/scrapers/AUS/NSW/index.js
+++ b/src/shared/scrapers/AUS/NSW/index.js
@@ -1,12 +1,21 @@
+import assert from 'assert';
 import * as parse from '../../../lib/parse.js';
 import * as fetch from '../../../lib/fetch/index.js';
 import maintainers from '../../../lib/maintainers.js';
-import { DeprecatedError } from '../../../lib/errors.js';
 
-/**
- * @param {Cheerio} $row
- */
-const parseRow = $row => parse.number($row.find('td:last-child').text());
+const getKey = rowLabel => {
+  const lowerLabel = rowLabel.toLowerCase();
+  if (lowerLabel.includes('confirmed cases')) {
+    return 'cases';
+  }
+  if (lowerLabel.includes('total')) {
+    return 'tested';
+  }
+  if (lowerLabel.includes('tested and excluded')) {
+    return 'discard';
+  }
+  throw new Error(`unknown row: ${lowerLabel}`);
+};
 
 const scraper = {
   country: 'AUS',
@@ -23,24 +32,22 @@ const scraper = {
   type: 'table',
   url:
     'https://www.health.nsw.gov.au/_layouts/feed.aspx?xsl=1&web=/news&page=4ac47e14-04a9-4016-b501-65a23280e841&wp=baabf81e-a904-44f1-8d59-5f6d56519965&pageurl=/news/Pages/rss-nsw-health.aspx',
-  scraper: {
-    '0': async function() {
-      const $ = await fetch.page(this.url);
-      const anchors = $('channel > item > link');
-      const currentArticleUrl = anchors[0].next.data;
-      const $currentArticlePage = await fetch.page(currentArticleUrl);
-      const $table = $currentArticlePage('.maincontent table:first-of-type');
+  async scraper() {
+    const $ = await fetch.page(this.url);
+    const $anchors = $('channel > item:contains("statistics") > link');
+    const currentArticleUrl = $anchors[0].next.data;
+    const $currentArticlePage = await fetch.page(currentArticleUrl);
 
-      return {
-        state: scraper.state,
-        cases: parseRow($table.find('tbody > tr:nth-child(2)')),
-        tested: parseRow($table.find('tbody > tr:last-child'))
-      };
-    },
-    '2020-3-28': async function() {
-      await fetch.page(this.url);
-      throw new DeprecatedError('NSW page seems to be broken');
-    }
+    const $table = $currentArticlePage('.maincontent table:first-of-type');
+    const $trs = $table.find('tbody > tr:not(:first-child)');
+    const data = { state: this.state };
+    $trs.each((index, tr) => {
+      const $tr = $(tr);
+      const key = getKey($tr.find('td:first-child').text());
+      data[key] = parse.number($tr.find('td:last-child').text());
+    });
+    assert(data.cases > 0, 'Cases is not reasonable');
+    return data;
   }
 };
 

--- a/src/shared/scrapers/AUS/NT/index.js
+++ b/src/shared/scrapers/AUS/NT/index.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as parse from '../../../lib/parse.js';
 import * as fetch from '../../../lib/fetch/index.js';
 import maintainers from '../../../lib/maintainers.js';
@@ -8,8 +9,8 @@ const scraper = {
   priority: 2,
   sources: [
     {
-      description: 'Nothern Territory Government Coronavirus site',
-      name: 'Nothern Territory Government Coronavirus site',
+      description: 'Northern Territory Government Coronavirus site',
+      name: 'Northern Territory Government Coronavirus site',
       url: 'https://coronavirus.nt.gov.au'
     }
   ],
@@ -19,10 +20,13 @@ const scraper = {
   async scraper() {
     const $ = await fetch.page(this.url);
     const $rowWithCases = $('.header-widget p:first-of-type');
-    return {
-      state: scraper.state,
+    assert($rowWithCases.text().includes('confirmed cases'));
+    const data = {
+      state: this.state,
       cases: parse.number($rowWithCases.text())
     };
+    assert(data.cases > 0, 'Cases is not reasonable');
+    return data;
   }
 };
 

--- a/src/shared/scrapers/AUS/QLD/index.js
+++ b/src/shared/scrapers/AUS/QLD/index.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as parse from '../../../lib/parse.js';
 import * as fetch from '../../../lib/fetch/index.js';
 import maintainers from '../../../lib/maintainers.js';
@@ -29,7 +30,7 @@ const scraper = {
       const paragraph = $('#content h2:first-of-type + p').text();
       const { casesString } = paragraph.match(/state total to (?<casesString>\d+)./).groups;
       return {
-        state: scraper.state,
+        state: this.state,
         cases: parse.number(casesString)
       };
     },
@@ -37,10 +38,12 @@ const scraper = {
       const $ = await getCurrentArticlePage(this.url);
       const $table = $('#content table');
       const $totalRow = $table.find('tbody > tr:last-child');
-      return {
-        state: scraper.state,
+      const data = {
+        state: this.state,
         cases: parse.number($totalRow.find('td:last-child').text())
       };
+      assert(data.cases > 0, 'Cases is not reasonable');
+      return data;
     }
   }
 };

--- a/src/shared/scrapers/AUS/SA/index.js
+++ b/src/shared/scrapers/AUS/SA/index.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as parse from '../../../lib/parse.js';
 import * as fetch from '../../../lib/fetch/index.js';
 import maintainers from '../../../lib/maintainers.js';
@@ -37,7 +38,7 @@ const scraper = {
       const paragraph = $('.middle-column p:first-of-type').text();
       const { casesString } = paragraph.match(/been (?<casesString>\d+) confirmed cases/).groups;
       return {
-        state: scraper.state,
+        state: this.state,
         cases: parse.number(casesString)
       };
     },
@@ -46,12 +47,13 @@ const scraper = {
       const $ = await fetch.page(this.url);
       const $table = $('table:first-of-type');
       const $trs = $table.find('tbody > tr:not(:first-child)');
-      const data = { state: scraper.state };
+      const data = { state: this.state };
       $trs.each((index, tr) => {
         const $tr = $(tr);
         const key = getKey($tr.find('td:first-child').text());
         data[key] = parse.number($tr.find('td:last-child').text());
       });
+      assert(data.cases > 0, 'Cases is not reasonable');
       return data;
     }
   }

--- a/src/shared/scrapers/AUS/WA/index.js
+++ b/src/shared/scrapers/AUS/WA/index.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as parse from '../../../lib/parse.js';
 import * as fetch from '../../../lib/fetch/index.js';
 import maintainers from '../../../lib/maintainers.js';
@@ -40,7 +41,7 @@ const scraper = {
     const $ = await fetch.page(this.url);
     const $table = $('table:first-of-type');
     const $trs = $table.find('tbody > tr:not(:first-child)');
-    const data = { state: scraper.state };
+    const data = { state: this.state };
     $trs.each((index, tr) => {
       const $tr = $(tr);
       const key = getKey($tr.find('td:first-child').text());
@@ -49,6 +50,7 @@ const scraper = {
     if (data.tested > 0) {
       data.tested += data.cases; // `tested` is only tested negative in this table, add the positive tested.
     }
+    assert(data.cases > 0, 'Cases is not reasonable');
     return data;
   }
 };

--- a/src/shared/scrapers/AUS/index.js
+++ b/src/shared/scrapers/AUS/index.js
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import * as fetch from '../../lib/fetch/index.js';
 import * as parse from '../../lib/parse.js';
 import * as transform from '../../lib/transform.js';
@@ -26,13 +27,20 @@ const scraper = {
     $trs.each((index, tr) => {
       const $tr = $(tr);
       const state = parse.string($tr.find('td:first-child').text());
-      const cases = parse.number($tr.find('td:nth-child(2)').text());
+      const cases = parse.number($tr.find('td:last-child').text());
       states.push({
         state,
         cases
       });
     });
-    states.push(transform.sumData(states));
+    const summedData = transform.sumData(states);
+    states.push(summedData);
+
+    const casesFromTotalRow = parse.number($table.find('tbody > tr:last-child > td:last-child').text());
+
+    assert(casesFromTotalRow > 0, 'Total row is not reasonable');
+    assert.equal(summedData.cases, casesFromTotalRow, 'Summed total is not equal to number in total row');
+
     return states;
   }
 };


### PR DESCRIPTION
Was originally trying to harden some of the AUS scrapers, but then realised that ACT changed their whole website in the middle of a Sunday (why not) so wrote a new scraper for that too.

Now that everywhere has corona cases it might be worth doing a similar assertion globally; interested in your thoughts.