### PR TITLE
Add sickly.app to homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -125,6 +125,7 @@
                 <li><a class="spectrum-Link" href="https://coronatab.app/dashboard" target="_blank"><strong>Pretty Browser extension + REST API</strong></a> from CoronaTab</li>
                 <li><a class="spectrum-Link" href="http://www.casualhacker.net/covid19" target="_blank"><strong>Compare Stats Among Countries and US States</strong></a> by Tim Newsome</li>
                 <li><a class="spectrum-Link" href="https://bibbase.org/other/covid-19" target="_blank"><strong>Plot and compare regions (incl. counties)</strong></a> by BibBase.org</li>
+                <li><a class="spectrum-Link" href="https://sickly.app" target="_blank"><strong>Explore the latest data down to the county level on a global map and per-location graphs</strong></a> by Sickly.app</li>
               </ul>
             </nav>
 


### PR DESCRIPTION
This PR proposes adding [Sickly.app](https://sickly.app) to the homepage. Sickly uses CDS data to visualize the number of reported cases down to the county level.

![sicklyss](https://user-images.githubusercontent.com/29695350/77867070-4feec700-71fb-11ea-9885-cfbe0cf6fd2c.png)
